### PR TITLE
Changing profile defaults to prevent AP/mesh conflicts 

### DIFF
--- a/files/profiles.d/defaultAP
+++ b/files/profiles.d/defaultAP
@@ -1,4 +1,4 @@
-ssid=commotionwireless.net
+ssid=commotionwireless
 channel=5
 ip=101.0.0.0
 ipgenerate=true

--- a/files/profiles.d/defaultSec
+++ b/files/profiles.d/defaultSec
@@ -1,5 +1,4 @@
-ssid=commotionwireless.net
-bssid=02:CA:FF:EE:BA:BE
+ssid=commotion_wpa
 channel=5
 ip=103.0.0.0
 ipgenerate=true


### PR DESCRIPTION
Would prefer to use commotionwireless.net in defaultAP instead of defaultMesh, but that seems like it would conflict with PR3 defaults.
