### PR TITLE
Fix "hang" bug

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -66,8 +66,13 @@ int dispatcher_cb(void *self, void *context) {
 
   int received = sock->receive(sock, buffer, sizeof(buffer));
   DEBUG("Received %d bytes.", received);
-  if(received <= 0) {
+  if(received == 0) {
     INFO("Received connection.");
+    return 1;
+  }
+  if (received < 0) {
+    INFO("Connection recvd() -1");
+    sock->hangup(sock, context);
     return 1;
   }
   co_msg_t *msgrcv = co_msg_unpack(buffer);

--- a/src/loop.c
+++ b/src/loop.c
@@ -269,7 +269,7 @@ int co_loop_add_socket(void *new_sock, void *context) {
   struct epoll_event event;
 
   memset(&event, 0, sizeof(struct epoll_event));
-  event.events = EPOLLIN | EPOLLET;
+  event.events = EPOLLIN;
 
   if((node = list_find(sockets, sock->uri, _co_loop_match_socket_i))) {
     CHECK((lnode_get(node) == sock), "Different socket with URI %s already registered.", sock->uri);

--- a/src/socket.c
+++ b/src/socket.c
@@ -154,8 +154,9 @@ int co_socket_receive(void *self, char *incoming, size_t length) {
     DEBUG("Receiving on listening socket.");
     if(this->rfd < 0) {
       socklen_t size = sizeof(*(this->remote));
-      DEBUG("Accepting connection.");
+      DEBUG("Accepting connection (fd=%d).", this->fd);
       CHECK((rfd = accept(this->fd, (struct sockaddr *) this->remote, &size)) != -1, "Failed to accept connection.");
+      DEBUG("Accepted connection (fd=%d).", rfd);
       this->rfd = rfd;
       int flags = fcntl(this->rfd, F_GETFL, 0);
       fcntl(this->rfd, F_SETFL, flags | O_NONBLOCK); //Set non-blocking.


### PR DESCRIPTION
Use level-triggered event mode for epoll(). This
will keep commotiond from hanging on multiple
simultaneous connections.
