### PR TITLE
Update mac80211.sh patch to respect UCI values.

### DIFF
--- a/openwrt/usr/share/commotion/patches/mac80211.sh.patch
+++ b/openwrt/usr/share/commotion/patches/mac80211.sh.patch
@@ -1,5 +1,5 @@
 --- mac80211.sh.orig	2013-05-17 15:00:14.427035173 -0400
-+++ mac80211.sh	2013-05-17 14:22:02.683650553 -0400
++++ mac80211.sh	2013-05-17 16:16:20.820470694 -0400
 @@ -1,6 +1,8 @@
  #!/bin/sh
  append DRIVERS "mac80211"
@@ -9,7 +9,7 @@
  mac80211_hostapd_setup_base() {
  	local phy="$1"
  	local ifname="$2"
-@@ -340,10 +342,43 @@
+@@ -340,10 +342,45 @@
  		[ -n "$ifname" ] || {
  			[ $i -gt 0 ] && ifname="wlan${phy#phy}-$i" || ifname="wlan${phy#phy}"
  		}
@@ -31,6 +31,8 @@
 +				uci_set wireless "$vif" encryption "psk2"
 +				config_set "$vif" key "$key"
 +				uci_set wireless "$vif" key "$key"
++			elif ["$encryption" = "false" ]; then
++				encryption="none"
 +			fi
 +			export channel
 +			iw dev "$ifname" set channel "$channel"
@@ -55,7 +57,7 @@
  
  		# It is far easier to delete and create the desired interface
  		case "$mode" in
-@@ -442,12 +477,27 @@
+@@ -442,12 +479,29 @@
  
  		case "$mode" in
  			adhoc)
@@ -72,6 +74,8 @@
 +					if [ "$encryption" = "true" ]; then 
 +						config_get key "$vif" key "$(commotion_get_wpakey $ifname)"
 +						encryption="psk2"
++					elif ["$encryption" = "false" ]; then
++						encryption="none"
 +					fi
 +				else
 +					config_get ssid "$vif" ssid


### PR DESCRIPTION
This updates the mac80211.sh.patch so that UCI values, such as those set through the LuCI interface, are respected over the default ones provided by commotiond.
