### PR TITLE
Use the maximum amount of entropy from node id during "network" IP generation

### DIFF
--- a/src/iface.c
+++ b/src/iface.c
@@ -403,7 +403,17 @@ int co_generate_ip(const char *base, const char *genmask, const nodeid_t id, cha
    * type, then set the last byte 
    * to '1'
    * */
-  if(type) addr.bytes[3] = 1;
+  if(type) {
+    /* 
+     * shift us over by one 
+     * to ensure that we are
+     * getting maximum entropy 
+     * from the mac address.
+     */
+    addr.bytes[1] = addr.bytes[2];
+    addr.bytes[2] = addr.bytes[3];
+    addr.bytes[3] = 1;
+  }
 
   /*
    * mask out the parts of address


### PR DESCRIPTION
When running on two very similar Unifi outdoor units, commotiond generated identical access point network addresses for two different nodes. The nodeids of the two nodes were so similar that commotiond generated mesh ip addresses that were identical except for the last octet. To remedy this, this patch shifts the octets left when generating network addresses.
