### PR TITLE
Dhcp timeout

### DIFF
--- a/openwrt/etc/config/commotiond
+++ b/openwrt/etc/config/commotiond
@@ -2,3 +2,4 @@ config daemon
 
 config node
 	option 'dhcp_timeout' '20'
+

--- a/openwrt/lib/netifd/proto/commotion.sh
+++ b/openwrt/lib/netifd/proto/commotion.sh
@@ -74,9 +74,9 @@ proto_commotion_setup() {
 
 	if [ "$type" = "plug" ]; then 
 		local dhcp_status
-		local dhcp_timeout="$(uci_get commotiond @node[0] dhcp_timeout)"
+		local dhcp_timeout="$(uci_get commotiond @node[0] dhcp_timeout "$DHCP_TIMEOUT")"
 		export DHCP_INTERFACE="$config"
-		udhcpc -q -i ${iface} -t 2 -T "${dhcp_timeout:-$DHCP_TIMEOUT}" -n -s /lib/netifd/commotion.dhcp.script
+		udhcpc -q -i ${iface} -t 2 -T "$dhcp_timeout" -n -s /lib/netifd/commotion.dhcp.script
 		dhcp_status=$?
 		export DHCP_INTERFACE=""
 		if [ $dhcp_status -eq 0 ]; then


### PR DESCRIPTION
This should be tested in conjunction with the dhcp-timeout pull request in luci-commotion: https://github.com/opentechinstitute/luci-commotion/pull/10

To test:
- start up node when connected to a gateway, and ensure it gets a DHCP lease.
- set dhcp_timeout to 1 in /etc/config/commotiond, reboot, and make sure it didn't get a lease this time
- remove the dhcp_timeout option from /etc/config/commotiond, reboot, and it should still get a DHCP lease (20 seconds is the default timeout)
