### PR TITLE
pretty print nested trees and lists

### DIFF
--- a/src/list.h
+++ b/src/list.h
@@ -140,4 +140,18 @@ size_t co_list_raw(char *output, const size_t olen, const co_obj_t *list);
  * @param ilen length of input buffer 
  */
 size_t co_list_import(co_obj_t **list, const char *input, const size_t ilen);
+
+/**
+ * @brief print list with indent
+ * @param list list  object to print
+ * @param indent level of indent
+ */
+void co_list_print_indent(co_obj_t *list, int indent);
+
+/**
+ * @brief print list
+ * @param list list object to print
+ */
+int co_list_print(co_obj_t *list);
+
 #endif

--- a/src/tree.h
+++ b/src/tree.h
@@ -193,6 +193,13 @@ size_t co_tree_raw(char *output, const size_t olen, const co_obj_t *tree);
 size_t co_tree_import(co_obj_t **tree, const char *input, const size_t ilen);
 
 /**
+ * @brief print tree with indent
+ * @param tree tree object to print
+ * @param indent level of indent
+ */
+void co_tree_print_indent(co_obj_t *tree, int indent);
+
+/**
  * @brief print tree
  * @param tree tree object to print
  */


### PR DESCRIPTION
updated and added printing functions for lists and trees to output fully formatted JSON-style nested objects

to test: write test program, build a complex nested object using lists and objects and various basic types, and print it using `co_list_print()` or `co_tree_print()`!

Here's code for a sample object:

```
CHECK_MEM((params = co_tree16_create()));
CHECK(co_tree_insert(params,"testint",sizeof("testint"),co_int8_create(-123,0)),"Failed to insert testint into request tree");
co_tree_insert(params,"testuint",sizeof("testuint"),co_uint8_create(123,0));
co_tree_insert(params,"testfloat",sizeof("testfloat"),co_float32_create(123.567,0));
co_obj_t *tree2 = co_tree16_create();
co_obj_t *tree3 = co_tree16_create();
co_tree_insert(tree3,"subtree2",sizeof("subtree2"),co_str8_create("subtree",sizeof("subtree"),0));
co_tree_insert(tree3,"blah",sizeof("blah"),co_str8_create("blah",sizeof("blah"),0));
co_tree_insert(tree2,"subtree",sizeof("subtree"),tree3);
co_tree_insert(tree2,"foo",sizeof("foo"),co_str8_create("foo",sizeof("foo"),0));
co_obj_t *list = co_list16_create();
co_list_append(list,co_str8_create("bar",sizeof("bar"),0));
co_tree_insert(tree2,"bar",sizeof("bar"),list);
co_obj_t *tree4 = co_tree16_create();
co_tree_insert(tree4,"baz",sizeof("baz"),co_str8_create("baz",sizeof("baz"),0));
co_list_append(list,tree4);
co_obj_t *list2 = co_list16_create();
co_list_append(list2,co_str8_create("egg",sizeof("egg"),0));
co_list_append(list,list2);
CHECK(co_tree_insert(params,"test3",sizeof("test3"),tree2),"Failed to insert tree2 into request tree");
co_tree_print(params);
```

And here's what it should print out:

```
  {
    "test3": 
      {
        "bar": 
          [
            "bar",
            {
              "baz": "baz"
            },
            [
              "egg"
            ]
          ],
        "foo": "foo",
        "subtree": 
          {
            "blah": "blah",
            "subtree2": "subtree"
          }
      },
    "testfloat": 123.567001,
    "testint": -123,
    "testuint": 123
  }
```
