### PR TITLE
Correct error checking for # of parameters to 'get' command.

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -536,7 +536,7 @@ CMD(get)
 {
   *output = co_tree16_create();
   size_t plen = co_list_length(params);
-  CHECK(((plen == 2) || (plen == 1)), "Incorrect parameters.");
+  CHECK((plen == 2), "Incorrect parameters.");
   co_obj_t *prof = NULL;
 
   if(!co_str_cmp_str(co_list_element(params, 0), "global"))


### PR DESCRIPTION
Corrects #78. Providing an insufficient number of parameters to the 'get' command no longer causes it to crash.

To test, run just 'get TEST' where 'TEST' is the name of a profile. You should get an 'invalid parameters' error and the daemon should not crash.
