### PR TITLE
Better integration between CTest and GTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
-set(PROJECT_NAME_STR commotion)
+SET(PROJECT_NAME_STR commotion)
 PROJECT(${PROJECT_NAME_STR})
 SET(NO_OPTIMIZE ON CACHE BOOL "Disable optimization flags.")
 SET(DEBUG ON CACHE BOOL "Turn on debugging.")
@@ -47,27 +47,27 @@ IF(PLUGINS)
   ADD_SUBDIRECTORY(plugins)
 ENDIF()
 
-if(NOT OPENWRT)
-  find_package(Doxygen)
-  if(DOXYGEN_FOUND)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-    add_custom_target(doc ALL
+IF(NOT OPENWRT)
+  FIND_PACKAGE(Doxygen)
+  IF(DOXYGEN_FOUND)
+    CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/doxygen/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+    ADD_CUSTOM_TARGET(doc ALL
       ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       COMMENT "Generating API documentation with Doxygen" VERBATIM
     )
-  endif(DOXYGEN_FOUND)
-endif()
+  ENDIF(DOXYGEN_FOUND)
+ENDIF()
 
 INSTALL(FILES files/commotiond.conf DESTINATION /etc/commotion)
 INSTALL(DIRECTORY files/profiles.d DESTINATION /etc/commotion)
 
 # uninstall target
-configure_file(
+CONFIGURE_FILE(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
     IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
+ADD_CUSTOM_TARGET(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
 REMOVE_DEFINITIONS("--std=gnu99")
-project(gtest_builder C CXX)
-include(ExternalProject)
+PROJECT(gtest_builder C CXX)
+INCLUDE(ExternalProject)
 
 ExternalProject_Add(googletest
     SVN_REPOSITORY http://googletest.googlecode.com/svn/trunk
@@ -16,34 +16,34 @@ ExternalProject_Add(googletest
 
 # Specify include dir
 ExternalProject_Get_Property(googletest source_dir)
-set(GTEST_INCLUDE_DIR ${source_dir}/include)
+SET(GTEST_INCLUDE_DIR ${source_dir}/include)
 
 # Specify MainTest's link libraries
 ExternalProject_Get_Property(googletest binary_dir)
-set(GTEST_LIBRARY ${binary_dir}/libgtest.a)
-set(GTEST_MAIN_LIBRARY ${binary_dir}/libgtest_main.a)
+SET(GTEST_LIBRARY ${binary_dir}/libgtest.a)
+SET(GTEST_MAIN_LIBRARY ${binary_dir}/libgtest_main.a)
 
 #-------------------
 # Test
 #-------------------
-enable_testing()
-include(FindGTest QUIETLY)
-set(PROJECT_TEST_NAME ${PROJECT_NAME_STR}_test)
-include_directories(${GTEST_INCLUDE_DIR} ${COMMON_INCLUDES})
+ENABLE_TESTING()
+INCLUDE(FindGTest QUIETLY)
+SET(PROJECT_TEST_NAME ${PROJECT_NAME_STR}_test)
+INCLUDE_DIRECTORIES(${GTEST_INCLUDE_DIR} ${COMMON_INCLUDES})
 
-file(GLOB TEST_SRC_FILES ${PROJECT_SOURCE_DIR}/*.cpp)
-add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES})
-add_dependencies(${PROJECT_TEST_NAME} googletest)
+FILE(GLOB TEST_SRC_FILES ${PROJECT_SOURCE_DIR}/*.cpp)
+ADD_EXECUTABLE(${PROJECT_TEST_NAME} ${TEST_SRC_FILES})
+ADD_DEPENDENCIES(${PROJECT_TEST_NAME} googletest)
 
-target_link_libraries(${PROJECT_TEST_NAME} commotion)
-target_link_libraries(${PROJECT_TEST_NAME}
+TARGET_LINK_LIBRARIES(${PROJECT_TEST_NAME} commotion)
+TARGET_LINK_LIBRARIES(${PROJECT_TEST_NAME}
 	${GTEST_LIBRARY}
 	${GTEST_MAIN_LIBRARY})
-target_link_libraries(${PROJECT_TEST_NAME} pthread)
+TARGET_LINK_LIBRARIES(${PROJECT_TEST_NAME} pthread)
 
 GTEST_ADD_TESTS(${PROJECT_TEST_NAME} "" ${TEST_SRC_FILES})
 
-add_custom_command(TARGET ${PROJECT_TEST_NAME} POST_BUILD COMMAND ${PROJECT_TEST_NAME})
+ADD_CUSTOM_COMMAND(TARGET ${PROJECT_TEST_NAME} POST_BUILD COMMAND ${PROJECT_TEST_NAME})
 
 #get_cmake_property(_variableNames VARIABLES)
 #foreach (_variableName ${_variableNames})


### PR DESCRIPTION
This pull request implements better integration between CMake's built-in CTest framework and the GoogleTests we use for unit testing. Previously all GTests were run as a single CTest under 'make test', but now they are split out individually for more useful output. Additionally, unit tests are now run by default as part of the build process.

To test:
1. Create a clean build. You should see the unit tests as part of the build process output.
2. Run 'make test.' You should see several individual tests run instead of just one test.
