### PR TITLE
free response list from co_call

### DIFF
--- a/src/commotion.c
+++ b/src/commotion.c
@@ -227,11 +227,9 @@ co_call(co_obj_t *connection, co_obj_t **response, const char *method, const siz
   }
   else SENTINEL("Failed to receive data.");
 
-  co_obj_free(m);
-  if(params != request) co_obj_free(params);
-  return retval;
-  
 error:
+  if (rlist)
+    co_obj_free(rlist);
   co_obj_free(m);
   if(params != request) co_obj_free(params);
   return retval;


### PR DESCRIPTION
This memory leak appears to be responsible for the olsrd memory usage issue we've been seeing in 1.1 release testing.
