### PR TITLE
Mesh over ethernet

### DIFF
--- a/openwrt/lib/netifd/proto/commotion.sh
+++ b/openwrt/lib/netifd/proto/commotion.sh
@@ -146,7 +146,7 @@ proto_commotion_setup() {
 	      	uci_commit firewall
 	      	set_bridge "$client_bridge" "$iface"
 	      	logger -t "commotion.proto" "Adding $iface to bridge $client_bridge"
-          logger -t "commotion.proto.dhcp" "DHCP type: $dhcp"
+		logger -t "commotion.proto.dhcp" "DHCP type: $dhcp"
 	      	
 	      	logger -t "commotion.proto" "Restarting $client_bridge interface"
 	      	ubus call network.interface."$client_bridge" down
@@ -168,15 +168,15 @@ proto_commotion_setup() {
 	      	
 	      	logger -t "commotion.proto" "Removing $iface from bridge $client_bridge"
 	      	#Can't use unset_bridge here, short-circuits startup process by calling *_teardown
-          brctl delif br-"$client_bridge" "$iface"
+		brctl delif br-"$client_bridge" "$iface"
 	      	proto_export "DHCP_INTERFACE=$config"
-		      logger -t "commotion.proto.dhcp" "DHCP type: $dhcp"
+		logger -t "commotion.proto.dhcp" "DHCP type: $dhcp"
 	      	proto_run_command "$config" udhcpc -i ${iface} -f -T "$dhcp_timeout" -t 0 -p /var/run/udhcpc-"$iface".pid -s /lib/netifd/commotion.dhcp.script
 		return
         ;;
 	"none")
 	      	#Can't use unset_bridge here, short-circuits startup process by calling *_teardown
-		      brctl delif br-"$client_bridge" "$iface"
+		brctl delif br-"$client_bridge" "$iface"
 	;;
       esac
       ;;
@@ -187,7 +187,7 @@ proto_commotion_setup() {
 	if [ $have_ip -eq 0 ]; then
 		if [ "$class" != "mesh" ]; then
 			if [ "$class" == "wired" -a "$dhcp" == "none" ]; then
-        logger -t "commotion.proto.none" "setting ipaddr: $ipaddr and netmask: $netmask"
+				logger -t "commotion.proto.none" "setting ipaddr: $ipaddr and netmask: $netmask"
 				local ip="$ipaddr" 
 				local netmask="$netmask"
 			else 


### PR DESCRIPTION
This pull request, in combination with https://github.com/opentechinstitute/luci-commotion/issues/430, addresses opentechinstitute/commotion-router#128 and opentechinstitute/commotion-router#143 by changing the way that the bridge is handled for wired interfaces in different DHCP modes.

To test meshing over ethernet:
- flash a node and run through setup wizard
- In "Additional Network Interfaces," set the node to mesh over ethernet, with address 172.16.1.1 and netmask 255.255.0.0
- Save changes and then login to the node over ssh. Check /etc/config/olsrd and /var/etc/olsrd.conf to see if they have an 'Interface' stanza for the ethernet interface, make sure the ethernet interface has the configured address, and that /etc/config/firewall has the 'wan' interface in the 'mesh' zone.
- Perform the steps above for a second node, but set the address to 172.16.1.2
- Connect the two nodes together via ethernet, and connect to the wireless AP of one node.
- Check the status page to make sure that they are receiving routes via their ethernet interface. If they are meshing over wireless and you can't tell for certain which routes are for the ethernet interface, considering changing the wireless settings for the mesh interface on one node so that they no longer mesh wirelessly.

To test DHCP:
- flash a node and run through setup wizard
- In "Additional Network Interfaces," set the node to always give out DHCP leases.
- Connect to the node's ethernet interface and make sure that you get a DHCP lease in the 10.0.0.0/8 range.
- Connect to the node over SSH and use 'brctl show' to make sure the ethernet interface is part of bridge 'br-lan'.
- In "Additional Network Interfaces," set the node to only ever request a DHCP lease.
- Connect the node's ethernet port to an internet gateway.
- Connect to the node's wireless AP and see if you have access to the internet.
- Connect to the node over SSH and use 'brctl show' to make sure the ethernet interface is not part of bridge 'br-lan'.
