### PR TITLE
increases buffer sizes for socket comms, until more elegant solution is decided upon

### DIFF
--- a/src/commotion.c
+++ b/src/commotion.c
@@ -40,8 +40,8 @@
 #include "msg.h"
 #include "commotion.h"
 
-#define REQUEST_MAX 4096
-#define RESPONSE_MAX 4096
+#define REQUEST_MAX 65536
+#define RESPONSE_MAX 65536
 
 static co_obj_t *_pool = NULL;
 static co_obj_t *_sockets = NULL;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -55,8 +55,8 @@
 #include "list.h"
 #include "tree.h"
 
-#define REQUEST_MAX 1024
-#define RESPONSE_MAX 1024
+#define REQUEST_MAX 4096
+#define RESPONSE_MAX 4096
 
 extern co_socket_t unix_socket_proto;
 static int pid_filehandle;
@@ -1012,6 +1012,13 @@ int main(int argc, char *argv[]) {
   CMD_REGISTER(save, "save <profile> [<filename>]", "Save profile to a file in the profiles directory.");
   CMD_REGISTER(new, "new <profile>", "Create a new profile.");
   CMD_REGISTER(delete, "delete <profile>", "Delete a profile.");
+  
+  struct sigaction sa = {{0}};
+  sa.sa_handler = SIG_IGN; // handle socket errors gracefully
+  if (sigaction(SIGPIPE, &sa, 0) == -1) {
+    perror("Error setting signal handler");
+    exit(1);
+  }
   
   /* Set up sockets */
   co_socket_t *socket = (co_socket_t*)NEW(co_socket, unix_socket);


### PR DESCRIPTION
also causes daemon to ignore SIGPIPE signals, so socket errors don't bring down the whole thing.
