### PR TITLE
Fix bridge support

### DIFF
--- a/openwrt/etc/config/commotiond
+++ b/openwrt/etc/config/commotiond
@@ -1,5 +1,4 @@
 config daemon
 
 config node
-	option 'dhcp_timeout' '20'
 

--- a/openwrt/lib/functions/commotion.sh
+++ b/openwrt/lib/functions/commotion.sh
@@ -39,24 +39,26 @@ is_false() {
   return 1
 }
   
-unset_bridge() {
-  local bridge="$1"
+remove_device() {
+  local config="$1"
   local ifname="$2"
   
   json_init
   json_add_string name "$ifname"
-  ubus call network.interface.$bridge remove_device "$(json_dump)" 2>/dev/null
+  json_add_string link-ext "true"
+  ubus call network.interface.$config remove_device "$(json_dump)" 2>/dev/null
   
   return $?
 }
   
-set_bridge() {
-  local bridge="$1"
+add_device() {
+  local config="$1"
   local ifname="$2"
   
   json_init
   json_add_string name "$ifname"
-  ubus call network.interface.$bridge add_device "$(json_dump)" 2>/dev/null
+  json_add_string link-ext "true"
+  ubus call network.interface.$config add_device "$(json_dump)" 2>/dev/null
   
   return $?
 }

--- a/openwrt/lib/netifd/proto/commotion.sh
+++ b/openwrt/lib/netifd/proto/commotion.sh
@@ -11,6 +11,8 @@ DEFAULT_CLIENT_BRIDGE="lan"
 DEFAULT_CLIENT_SUBNET="10.0.0.0"
 DEFAULT_CLIENT_NETMASK="255.255.255.0"
 DEFAULT_CLIENT_IPGENMASK="255.0.0.0"
+DHCP_TIMEOUT="10"
+DHCP_TRIES="1"
 WIFI_DEVICE=
 TYPE=
 
@@ -98,9 +100,10 @@ proto_commotion_setup() {
 				"auto")
 					local dhcp_status
 					local dhcp_timeout="$(uci_get commotiond @node[0] dhcp_timeout "$DHCP_TIMEOUT")"
+					local dhcp_tries="$(uci_get commotiond @node[0] dhcp_tries "$DHCP_TRIES")"
 					logger -t "commotion.proto" "Removing $iface from bridge $client_bridge"
 					export DHCP_INTERFACE="$config"
-					udhcpc -q -i ${iface} -p /var/run/udhcpc-${iface}.pid -t 2 -T "$dhcp_timeout" -n -s /lib/netifd/commotion.dhcp.script
+					udhcpc -q -i ${iface} -p /var/run/udhcpc-${iface}.pid -t "$dhcp_tries" -T "$dhcp_timeout" -n -s /lib/netifd/commotion.dhcp.script
 					dhcp_status=$?
 					export DHCP_INTERFACE=""
 					if [ $dhcp_status -eq 0 ]; then

--- a/openwrt/lib/netifd/proto/commotion.sh
+++ b/openwrt/lib/netifd/proto/commotion.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# vim: set noexpandtab:
 
 . /lib/functions.sh
 . /lib/functions/commotion.sh
@@ -43,7 +44,7 @@ configure_wifi_device() {
 	local config="$1"
 	local thisradio="$2"	
 	local channel="$3"
-	
+
 	[[ "$config" == "$thisradio" ]] && {
 		config_set "$config" channel "$channel"
 	}
@@ -66,8 +67,8 @@ proto_commotion_setup() {
 	local have_ip=0
 	local dhcp=
 	local client_bridge="$(uci_get network "$config" client_bridge "$DEFAULT_CLIENT_BRIDGE")"
-	
-	local profile type ipaddr netmask dns domain announce lease_zone nolease_zone
+
+	local profile type class ipaddr netmask dns domain announce lease_zone nolease_zone
 	json_get_vars profile type class ipaddr netmask dns domain announce lease_zone nolease_zone
 
 	logger -t commotion.proto "Running protocol handler."
@@ -75,115 +76,96 @@ proto_commotion_setup() {
 		commotion_up "$iface" $(uci_get network $config profile)
 	}
 	case "$class" in
- 	"mesh")
-		logger -t "commotion.proto" "Class: $class"
-		commotion_up "$iface" $(uci_get network $config profile)
-		logger -t "commotion.proto" "Upped $iface"
-		uci_set_state network "$config" meshed "$(uci_get network "$config" meshed 1)"
-		uci_set_state network "$config" announced "$(uci_get network "$config" announced 0)"
-      	;;
-	"client")
-		logger -t "commotion.proto" "Class: $class"
-		uci_set_state network "$config" meshed "$(uci_get network "$config" meshed 0)"
-		uci_set_state network "$config" announced "$(uci_get network "$config" announced 1)"
-      	;;
-	"wired")
-		logger -t "commotion.proto" "Class: $class"
-		uci_set_state network "$config" meshed "$(uci_get network "$config" meshed 0)"
-		uci_set_state network "$config" announced "$(uci_get network "$config" announced 0)"
-		dhcp="$(uci_get network "$config" dhcp "auto")"
-      		uci_set_state network "$config" dhcp "$dhcp"
-      
-      case "$dhcp" in
-        "auto")
-	      	local dhcp_status
-	      	local dhcp_timeout="$(uci_get commotiond @node[0] dhcp_timeout "$DHCP_TIMEOUT")"
-	      	
-	      	logger -t "commotion.proto" "Removing $iface from bridge $client_bridge"
-	      	#Can't use unset_bridge here, short-circuits startup process by calling *_teardown
-          brctl delif br-"$client_bridge" "$iface"
-	      	logger -t "commotion.proto" "Successfully removed $iface from bridge $client_bridge"
-	      	export DHCP_INTERFACE="$config"
-	      	udhcpc -q -i ${iface} -p /var/run/udhcpc-${iface}.pid -t 2 -T "$dhcp_timeout" -n -s /lib/netifd/commotion.dhcp.script
-	      	dhcp_status=$?
-	      	export DHCP_INTERFACE=""
-	      	if [ $dhcp_status -eq 0 ]; then
-	      		# we got an IP
-	      		# see commotion.dhcp.script for the rest of
-	      		# the setup code.
-
-	      		# get out of here early.
-	      		return
-	      	else
-	      		unset_fwzone "$config"
-	      		uci_commit firewall
-	      		set_bridge "$client_bridge" "$iface"
-	      		logger -t "commotion.proto" "Adding $iface to bridge $client_bridge"
-	      		
-	      		logger -t "commotion.proto" "Restarting $client_bridge interface"
-	      		ubus call network.interface."$client_bridge" down
-	      		ubus call network.interface."$client_bridge" up
-	      		local bridge_ip="$(uci_get_state network $client_bridge ipaddr $(commotion_gen_ip $DEFAULT_CLIENT_SUBNET $DEFAULT_CLIENT_IPGENMASK gw))"
-	      		logger -t "commotion.proto" "Bridge IP state: $(uci_get_state $client_bridge ipaddr)"
-	      		logger -t "commotion.proto" "Bridge generated IP: $(commotion_gen_ip $DEFAULT_CLIENT_SUBNET $DEFAULT_CLIENT_IPGENMASK gw)"
-	      		local bridge_netmask="$(uci_get_state network $client_bridge netmask $DEFAULT_CLIENT_NETMASK)"
-	      		logger -t "commotion.proto" "Bridge Netmask state: $(uci_get_state $client_bridge netmask)"
-	      		logger -t "commotion.proto" "Bridge Default netmask: $DEFAULT_CLIENT_NETMASK"
-	      		logger -t "commotion.proto" "Bridge: $client_bridge, IP: $bridge_ip, Netmask: $bridge_netmask"
-	      		uci_set network "$client_bridge" ipaddr "$bridge_ip"
-	      		uci_set_state network "$client_bridge" ipaddr "$bridge_ip"
-	      		uci_set network "$client_bridge" netmask "$bridge_netmask"
-	      		uci_set_state network "$client_bridge" netmask "$bridge_netmask"
-
-			logger -t "commotion.proto" "Restarting dnsmasq..."
-			/etc/init.d/dnsmasq restart
-
-			have_ip=1
-	      	fi
-        ;;
-        "server")
-	      	unset_fwzone "$config"
-	      	uci_commit firewall
-	      	set_bridge "$client_bridge" "$iface"
-	      	logger -t "commotion.proto" "Adding $iface to bridge $client_bridge"
-		logger -t "commotion.proto.dhcp" "DHCP type: $dhcp"
-	      	
-	      	logger -t "commotion.proto" "Restarting $client_bridge interface"
-	      	ubus call network.interface."$client_bridge" down
-	      	ubus call network.interface."$client_bridge" up
-	      	local bridge_ip="$(uci_get_state $client_bridge ipaddr $(commotion_gen_ip $DEFAULT_CLIENT_SUBNET $DEFAULT_CLIENT_IPGENMASK gw))"
-	      	local bridge_netmask="$(uci_get_state $client_bridge netmask $DEFAULT_CLIENT_SUBNET)"
-	      	logger -t "commotion.proto" "Bridge: $client_bridge, IP: $bridge_ip, Netmask: $bridge_netmask"
-	      	uci_set network "$client_bridge" ipaddr "$bridge_ip"
-	      	uci_set network "$client_bridge" netmask "$bridge_netmask"
-
-		logger -t "commotion.proto" "Restarting dnsmasq..."
-		/etc/init.d/dnsmasq restart
-
-		have_ip=1
-        ;;
-        "client")
-	      	local dhcp_status
-	      	local dhcp_timeout="$(uci_get commotiond @node[0] dhcp_timeout "$DHCP_TIMEOUT")"
-	      	
-	      	logger -t "commotion.proto" "Removing $iface from bridge $client_bridge"
-	      	#Can't use unset_bridge here, short-circuits startup process by calling *_teardown
-		brctl delif br-"$client_bridge" "$iface"
-	      	proto_export "DHCP_INTERFACE=$config"
-		logger -t "commotion.proto.dhcp" "DHCP type: $dhcp"
-	      	proto_run_command "$config" udhcpc -i ${iface} -f -T "$dhcp_timeout" -t 0 -p /var/run/udhcpc-"$iface".pid -s /lib/netifd/commotion.dhcp.script
-		return
-        ;;
-	"none")
-	      	#Can't use unset_bridge here, short-circuits startup process by calling *_teardown
-		brctl delif br-"$client_bridge" "$iface"
-	;;
-      esac
-      ;;
-  esac
+		"mesh")
+			logger -t "commotion.proto" "Class: $class"
+			commotion_up "$iface" $(uci_get network $config profile)
+			logger -t "commotion.proto" "Upped $iface"
+			uci_set_state network "$config" meshed "$(uci_get network "$config" meshed 1)"
+			uci_set_state network "$config" announced "$(uci_get network "$config" announced 0)"
+		;;
+		"client")
+			logger -t "commotion.proto" "Class: $class"
+			uci_set_state network "$config" meshed "$(uci_get network "$config" meshed 0)"
+			uci_set_state network "$config" announced "$(uci_get network "$config" announced 1)"
+		;;
+		"wired")
+			logger -t "commotion.proto" "Class: $class"
+			uci_set_state network "$config" meshed "$(uci_get network "$config" meshed 0)"
+			uci_set_state network "$config" announced "$(uci_get network "$config" announced 0)"
+			dhcp="$(uci_get network "$config" dhcp "auto")"
+			uci_set_state network "$config" dhcp "$dhcp"
+			case "$dhcp" in
+				"auto")
+					local dhcp_status
+					local dhcp_timeout="$(uci_get commotiond @node[0] dhcp_timeout "$DHCP_TIMEOUT")"
+					logger -t "commotion.proto" "Removing $iface from bridge $client_bridge"
+					export DHCP_INTERFACE="$config"
+					udhcpc -q -i ${iface} -p /var/run/udhcpc-${iface}.pid -t 2 -T "$dhcp_timeout" -n -s /lib/netifd/commotion.dhcp.script
+					dhcp_status=$?
+					export DHCP_INTERFACE=""
+					if [ $dhcp_status -eq 0 ]; then
+						logger -t "commotion.proto" "Received IP address via DHCP on $iface, exiting protocol handler."
+						# we got an IP
+						# see commotion.dhcp.script for the rest of
+						# the setup code.
+						# get out of here early.
+						return
+					else
+						logger -t "commotion.proto" "Failed to receive IP address via DHCP on $iface, continuing protocol handler."
+						unset_fwzone "$config"
+						uci_commit firewall
+						logger -t "commotion.proto" "Adding $iface to bridge $client_bridge"
+						add_device "$client_bridge" "$iface"
+						local bridge_ip="$(uci_get_state network $client_bridge ipaddr $(commotion_gen_ip $DEFAULT_CLIENT_SUBNET $DEFAULT_CLIENT_IPGENMASK gw))"
+						logger -t "commotion.proto" "Bridge IP state: $(uci_get_state $client_bridge ipaddr)"
+						logger -t "commotion.proto" "Bridge generated IP: $(commotion_gen_ip $DEFAULT_CLIENT_SUBNET $DEFAULT_CLIENT_IPGENMASK gw)"
+						local bridge_netmask="$(uci_get_state network $client_bridge netmask $DEFAULT_CLIENT_NETMASK)"
+						logger -t "commotion.proto" "Bridge Netmask state: $(uci_get_state $client_bridge netmask)"
+						logger -t "commotion.proto" "Bridge Default netmask: $DEFAULT_CLIENT_NETMASK"
+						logger -t "commotion.proto" "Bridge: $client_bridge, IP: $bridge_ip, Netmask: $bridge_netmask"
+						uci_set network "$client_bridge" ipaddr "$bridge_ip"
+						uci_set_state network "$client_bridge" ipaddr "$bridge_ip"
+						uci_set network "$client_bridge" netmask "$bridge_netmask"
+						uci_set_state network "$client_bridge" netmask "$bridge_netmask"
+						logger -t "commotion.proto" "Restarting dnsmasq..."
+						/etc/init.d/dnsmasq restart
+						have_ip=1
+					fi
+				;;
+				"server")
+					unset_fwzone "$config"
+					uci_commit firewall
+					add_device "$client_bridge" "$iface"
+					logger -t "commotion.proto" "Adding $iface to bridge $client_bridge"
+					logger -t "commotion.proto.dhcp" "DHCP type: $dhcp"
+					logger -t "commotion.proto" "Restarting $client_bridge interface"
+					ubus call network.interface."$client_bridge" down
+					ubus call network.interface."$client_bridge" up
+					local bridge_ip="$(uci_get_state $client_bridge ipaddr $(commotion_gen_ip $DEFAULT_CLIENT_SUBNET $DEFAULT_CLIENT_IPGENMASK gw))"
+					local bridge_netmask="$(uci_get_state $client_bridge netmask $DEFAULT_CLIENT_SUBNET)"
+					logger -t "commotion.proto" "Bridge: $client_bridge, IP: $bridge_ip, Netmask: $bridge_netmask"
+					uci_set network "$client_bridge" ipaddr "$bridge_ip"
+					uci_set network "$client_bridge" netmask "$bridge_netmask"
+					logger -t "commotion.proto" "Restarting dnsmasq..."
+					/etc/init.d/dnsmasq restart
+					have_ip=1
+				;;
+				"client")
+					local dhcp_status
+					local dhcp_timeout="$(uci_get commotiond @node[0] dhcp_timeout "$DHCP_TIMEOUT")"
+					proto_export "DHCP_INTERFACE=$config"
+					logger -t "commotion.proto.dhcp" "DHCP type: $dhcp"
+					proto_run_command "$config" udhcpc -i ${iface} -f -T "$dhcp_timeout" -t 0 -p /var/run/udhcpc-"$iface".pid -s /lib/netifd/commotion.dhcp.script
+					return
+				;;
+				"none")
+				;;
+			esac
+		;;
+	esac
 
 	proto_init_update "*" 1
-	
+
 	if [ $have_ip -eq 0 ]; then
 		if [ "$class" != "mesh" ]; then
 			if [ "$class" == "wired" -a "$dhcp" == "none" ]; then
@@ -209,7 +191,7 @@ proto_commotion_setup() {
 			logger -t "commotion.proto" "proto_add_dns_server: $dns"
 			proto_add_dns_search ${domain:-$(commotion_get_domain $iface)}          
 			logger -t "commotion.proto" "proto_add_dns_search: $domain"
-    		fi
+		fi
 	fi
 
 	proto_export "INTERFACE=$config"
@@ -222,7 +204,7 @@ proto_commotion_setup() {
 		config_foreach configure_wifi_iface wifi-iface $config
 		local channel=$(uci_get wireless "$WIFI_DEVICE" channel)
 		uci_set wireless $WIFI_DEVICE channel ${channel:-$(commotion_get_channel $iface)}
-    		uci_commit wireless
+		uci_commit wireless
 	fi
 	logger -t "commotion.proto" "Sending update for $config"
 	proto_send_update "$config"
@@ -231,19 +213,20 @@ proto_commotion_setup() {
 proto_commotion_teardown() {
 	local config="$1"
 	local ifname="$2"
-		
-	logger -t "commotion.proto" "Initiating teardown."
-	
-	local class = "$(uci_get network "$config" class)"
-	
+
+	logger -t "commotion.proto" "Initiating teardown of config: $config with ifname: $ifname."
+
+	local class="$(uci_get network "$config" class)"
+	logger -t "commotion.proto" "Interface config $config being torn down has class: $class."
+
 	if [ "$class" == "wired" ]; then
-	    local client_bridge="$(uci_get network "$config" client_bridge "$DEFAULT_CLIENT_BRIDGE")"
-	    unset_bridge "$client_bridge" "$ifname"
-	    logger -t "commotion.proto" "Removing $ifname from bridge $client_bridge"
-	
-	    proto_kill_command "$config"
+		local client_bridge="$(uci_get network "$config" client_bridge "$DEFAULT_CLIENT_BRIDGE")"
+		logger -t "commotion.proto" "Interface config $config being torn down has client_bridge: $client_bridge."
+		remove_device "$client_bridge" "$ifname"
+		add_device "$config" "$ifname"
+		logger -t "commotion.proto" "Removing $ifname from bridge $client_bridge"
 	fi
-}	
+}
 
 add_protocol commotion
 


### PR DESCRIPTION
This pull request fixes bridging again, to account for the fact that netifd now seems to send events when an interface is physically plugged or unplugged. Incidentally, this makes it so in the default 'auto' mode, the ethernet interface will attempt to detect whether it is a gateway every time the interface is plugged in, not just when the node is booted.

Also contains some much needed some much-needed cleanup of egregious indentation in the protocol handler script.
